### PR TITLE
Update documentation links in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Use the credentialagent-docker-compose repo
 1. `git clone https://github.com/velocitynetworkfoundation/credentialagent-docker-compose.git`
 1. `cd credentialagent-docker-compose`
 1. `cp .env_example .env`
-1. Fill in empty values (and optionally modify existing ones) in the .env. (See [Credential Agent Configuration](https://www.velocitynetwork.foundation/main/operators-guide-credential-agents#agent-server-configuration))
+1. Fill in empty values (and optionally modify existing ones) in the .env. (See [Credential Agent Operation](https://www.velocitynetwork.foundation/main/developers-guide-credential-agent-operation)
 1. `docker-compose pull`
 1. `docker-compose up`
 1. `curl http://localhost:8080` should return a successful response
@@ -20,5 +20,5 @@ Use the credentialagent-docker-compose repo
 
 #### Agent Env Configuration
 
-See [Credential Agent Configuration](https://www.velocitynetwork.foundation/main/operators-guide-credential-agents#agent-server-configuration)
+See [Credential Agent Operation](https://www.velocitynetwork.foundation/main/developers-guide-credential-agent-operation)
 for more information about setting up environment variables and configuring the credential agent


### PR DESCRIPTION
I fixed the links in the README to point to the newer Credential Agent Operation page.