### PR TITLE
Prevent external access to Mongo service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: mongo:4.0.4
     volumes:
       - ./mongo:/data/db
-    ports:
-      - 27018:27017
+    expose:
+      - 27017
 
   credentialagent-migrations:
     image: ghcr.io/velocitynetworkfoundation/credentialagent:testnet
@@ -25,4 +25,3 @@ services:
     restart: on-failure
     depends_on:
       - credentialagent-migrations
-


### PR DESCRIPTION
The current configuration publicly exposes the Mongo service without specifying authentication credentials, making it vulnerable to external attacks.

Exposing the 'velocity-mongo' container to the host does not appear to be necessary for a functional Credential Agent.

This change ensures that the service is inaccessible outside the Docker network, thereby improving overall security.